### PR TITLE
feature-tests-support-https

### DIFF
--- a/apilyzer/verify.py
+++ b/apilyzer/verify.py
@@ -142,7 +142,19 @@ async def check_swagger_rest(uri: str) -> dict:
 
 
 async def _supports_https(uri: str) -> dict:
-    """Check if the URI supports HTTPS."""
+    """Check if the given base URI of an API has support to HTTPS protocol.
+
+    Parameters:
+        uri (str): The base URI of the API.
+
+    Returns:
+        dict: A dictionary containing the 'status', 'message', and 'response' keys detailing the outcome of the check.
+
+    Examples:
+        >>> import asyncio
+        >>> asyncio.run(_supports_https('http://127.0.0.1:8000')) # doctest: +SKIP
+        {'status': 'success', 'message': 'The URI does not support HTTPS at http://127.0.0.1:8000/. ', 'response': '{...}'}
+    """
 
     https_uri = (
         uri.replace('http://', 'https://')

--- a/tests/test_verify.py
+++ b/tests/test_verify.py
@@ -1,6 +1,7 @@
 import asyncio
 
 from apilyzer.verify import (
+    _supports_https,
     analyze_api_maturity,
     check_swagger_rest,
     is_rest_api,
@@ -58,3 +59,17 @@ def test_analyze_api_maturity_invalid_url():
     result = asyncio.run(analyze_api_maturity('invalid_url'))
     assert result['status'] == 'error'
     assert 'invalid_url does not appear to be a REST API.' in result['message']
+
+
+def test_supports_https_success():
+    result = asyncio.run(
+        _supports_https('https://nv-research-tlv.netlify.app/')
+    )
+    assert result['status'] == 'success'
+    assert 'URI supports HTTPS' in result['message']
+
+
+def test_supports_https_failure():
+    result = asyncio.run(_supports_https('https://petstore.swagger.io/v2'))
+    assert result['status'] == 'error'
+    assert 'URI does not support HTTPS' in result['message']


### PR DESCRIPTION
Criação de dois testes, test_supports_https_success e test_supports_https_failure onde efetua um teste para fazer a validação de uma API que suporta o protocolo HTTPS e a validação de uma API que não apresenta suporte para o protocolo HTTPS, respectivamente.

Ambos os testes apenas validam se a resposta foi de fato a esperada, no exemplo da função test_supports_https_success, valida se a api https://nv-research-tlv.netlify.app/ apresenta suporte para o protocolo HTTPS e qual a mensagem de retorno.