### PR TITLE
feat-rate-limit

### DIFF
--- a/apilyzer/cli.py
+++ b/apilyzer/cli.py
@@ -3,7 +3,12 @@ import asyncio
 from rich.console import Console
 from typer import Argument, Context, Typer
 
-from apilyzer.verify import analyze_api_maturity, check_swagger_rest
+from apilyzer.verify import (
+    _is_rest_api,
+    analyze_api_maturity,
+    check_swagger_rest,
+    estimate_rate_limit,
+)
 
 console = Console()
 app = Typer()
@@ -56,6 +61,19 @@ def maturity(
     ),
 ):
     result = asyncio.run(analyze_api_maturity(url))
+    console.print(result)
+
+
+@app.command()
+def test_rate(
+    url: str = Argument(
+        'http://127.0.0.1:8000', help='URL of the API to verify.'
+    ),
+    rate: int = Argument(
+        '50', help='Number of requests to test if the API is able to resist.'
+    ),
+):
+    result = asyncio.run(estimate_rate_limit(url, rate))
     console.print(result)
 
 

--- a/apilyzer/cli.py
+++ b/apilyzer/cli.py
@@ -26,15 +26,18 @@ Atualmente, existem 2 subcomandos disponíveis para essa aplicação:
 
 - [b]verify-rest[/]: Verifica se uma API REST está documentada com base na URL fornecida e caso esteja, retorna o retorno da API
 - [b]maturity[/]: Analisa o nível de maturidade de uma API REST com base no modelo de maturidade de Richardson
+- [b]test_rate[/]: Efetua uma quantidade de requisições (100 por padrão) para a API com o objetivo de validar se a API tem um limite para a quantidade de requisições
 
 [b]Exemplos de uso:[/]
 
 [green]apilyzer verify-rest [/]
 [green]apilyzer maturity [/]
+[green]apilyzer test_rate [/]
 
 
 [green]apilyzer verify-rest https://petstore.swagger.io v2/swagger[/]
 [green]apilyzer maturity https://picpay.github.io/picpay-docs-digital-payments/swagger/checkout.json[/]
+[green]apilyzer test_rate https://petstore.swagger.io/v2/pet[/]
 
 
 [b]Para mais informações: [yellow]apilyzer --help[/]

--- a/apilyzer/cli.py
+++ b/apilyzer/cli.py
@@ -4,7 +4,7 @@ from rich.console import Console
 from typer import Argument, Context, Typer
 
 from apilyzer.verify import (
-    _is_rest_api,
+    _is_json_rest_api,
     analyze_api_maturity,
     check_swagger_rest,
     estimate_rate_limit,

--- a/apilyzer/verify.py
+++ b/apilyzer/verify.py
@@ -358,18 +358,18 @@ async def estimate_rate_limit(uri: str, max_requests: int):
             if response.status_code == 429:
                 return {
                     'status': 'error',
-                    'message': f'A API retornou um erro 429 (Too Many Requests). Isso indica que o limite de taxa da API foi excedido.',
+                    'message': f'The API returned a 429 error (too many requests). This indicates that the rate limit has been exceeded',
                     'response_code': response.status_code,
                 }
             return {
                 'status': 'success',
-                'message': 'Requisição bem-sucedida.',
+                'message': 'All requests were successful',
                 'response_code': response.status_code,
             }
         except httpx.RequestError as exc:
             return {
                 'status': 'error',
-                'message': f'Ocorreu um erro ao solicitar {uri}: {exc}',
+                'message': f'An error occurred while requesting {uri}: {exc}',
                 'response_code': None,
             }
 
@@ -385,6 +385,6 @@ async def estimate_rate_limit(uri: str, max_requests: int):
 
     return {
         'status': 'success',
-        'message': f'Todas as {max_requests} requisições foram bem-sucedidas sem erros 429. Isso sugere que a API pode suportar a quantidade especificada de requisições.',
+        'message': f'All of {max_requests} requests were successful without 429 errors. This suggests that the API can support the specified number of requests',
         'response_code': None,
     }

--- a/apilyzer/verify.py
+++ b/apilyzer/verify.py
@@ -350,6 +350,11 @@ async def estimate_rate_limit(uri: str, max_requests: int):
 
     Returns:
         dict: A dictionary containing feedback on how the API was able to support multiple parallel requests.
+
+    Examples:
+        >>> import asyncio
+        >>> asyncio.run(estimate_rate_limit('http://127.0.0.1:8000', 100)) # doctest: +SKIP
+        {'status': 'success', 'message': 'The API returned a 429 error (too many requests). This indicates that the rate limit has been exceeded', 'response': '{...}'}
     """
 
     async def make_request(session, uri):

--- a/tests/test_verify.py
+++ b/tests/test_verify.py
@@ -101,12 +101,26 @@ def test_analyze_api_maturity_invalid_url():
     assert 'No REST API documentation found' in result['message']
 
 
+def test_supports_https_success():
+    result = asyncio.run(
+        _supports_https('https://nv-research-tlv.netlify.app/')
+    )
+    assert result['status'] == 'success'
+    assert 'URI supports HTTPS' in result['message']
+
+
+def test_supports_https_failure():
+    result = asyncio.run(_supports_https('https://petstore.swagger.io/v2'))
+    assert result['status'] == 'error'
+    assert 'URI does not support HTTPS' in result['message']
+
+
 def test_estimate_rate_limit_success():
     api_url = 'https://petstore.swagger.io/v2/pet/1'
     max_requests = 100
     result = asyncio.run(estimate_rate_limit(api_url, max_requests))
     assert result['status'] == 'success'
-    assert 'requisições foram bem-sucedidas sem erros 429' in result['message']
+    assert 'requests were successful without 429 errors' in result['message']
 
 
 def test_estimate_rate_limit_request_error():
@@ -114,4 +128,4 @@ def test_estimate_rate_limit_request_error():
     max_requests = 100
     result = asyncio.run(estimate_rate_limit(api_url, max_requests))
     assert result['status'] == 'error'
-    assert 'Ocorreu um erro ao solicitar' in result['message']
+    assert 'An error occurred while requesting' in result['message']

--- a/tests/test_verify.py
+++ b/tests/test_verify.py
@@ -5,6 +5,7 @@ from apilyzer.verify import (
     _supports_https,
     analyze_api_maturity,
     check_swagger_rest,
+    estimate_rate_limit,
 )
 
 
@@ -76,15 +77,17 @@ def test_analyze_api_maturity_invalid_url():
     assert 'No REST API documentation found.' in result['message']
 
 
-def test_supports_https_success():
-    result = asyncio.run(
-        _supports_https('https://nv-research-tlv.netlify.app/')
-    )
+def test_estimate_rate_limit_success():
+    api_url = 'https://petstore.swagger.io/v2/pet/1'
+    max_requests = 100
+    result = asyncio.run(estimate_rate_limit(api_url, max_requests))
     assert result['status'] == 'success'
-    assert 'URI supports HTTPS' in result['message']
+    assert 'requisições foram bem-sucedidas sem erros 429' in result['message']
 
 
-def test_supports_https_failure():
-    result = asyncio.run(_supports_https('https://petstore.swagger.io/v2'))
+def test_estimate_rate_limit_request_error():
+    api_url = 'https://api-with-request-error.com'
+    max_requests = 100
+    result = asyncio.run(estimate_rate_limit(api_url, max_requests))
     assert result['status'] == 'error'
-    assert 'URI does not support HTTPS' in result['message']
+    assert 'Ocorreu um erro ao solicitar' in result['message']


### PR DESCRIPTION
Foi implementado a função e seus devidos testes para o teste de Rate Limit, no qual efetua uma série de requisições para a API para verificar se ela irá retornar o erro 429, Too Many Requests.

PS: Não consegui simular de fato o erro 429.